### PR TITLE
Npm trusted publishing integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
         run: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]


### PR DESCRIPTION
Switch npm package publishing to use GitHub Actions Trusted Publishing (OIDC).

This change eliminates the need for a long-lived `NPM_TOKEN` secret, enhancing supply-chain security and reducing secret management overhead. It requires a one-time configuration on npmjs.com to add this repository and workflow as a trusted publisher for the package.

---
<a href="https://cursor.com/background-agent?bcId=bc-213e3259-ddde-4d99-9315-aa8a38cf5776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-213e3259-ddde-4d99-9315-aa8a38cf5776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

