### PR TITLE
Commitlint github actions

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,15 @@
 export default {
   extends: ['@commitlint/config-conventional'],
+  ignores: [
+    (message) => {
+      const firstLine = message.split('\n')[0]?.trim() ?? '';
+      const ignoredSubjects = new Set([
+        'Refactor: Ensure backlog and ideas directories persist',
+        'Refactor docs and ideas structure',
+      ]);
+      return ignoredSubjects.has(firstLine);
+    },
+  ],
   rules: {
     'type-enum': [
       2,


### PR DESCRIPTION
Add specific commitlint ignore rules to allow legacy commit messages that were failing the Release workflow.

The Release workflow's commitlint step was failing because it was linting commits since the last tag (`v1.5.0`), which included two historical non-conventional commit messages. This PR adds a targeted ignore for only these two exact commit subjects, ensuring strict Conventional Commits enforcement for all other commits.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec64fc17-1bd3-4486-8d19-21d4c25f5ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec64fc17-1bd3-4486-8d19-21d4c25f5ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

