### PR TITLE
Release action failure investigation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Pass `NPM_TOKEN` as `NODE_AUTH_TOKEN` to `setup-node` action to fix release workflow authentication.

The release workflow was failing because `actions/setup-node@v4` requires the `NODE_AUTH_TOKEN` environment variable to be explicitly set in its `env` block to properly configure `.npmrc` for npm registry authentication. Previously, `NPM_TOKEN` was only available in a later step, leading to authentication failures during package publishing.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea34d5fe-b8d6-42a4-bdc9-633f75eb68f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ea34d5fe-b8d6-42a4-bdc9-633f75eb68f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

